### PR TITLE
.NET Standard 2 support

### DIFF
--- a/standard/lib60870.NET.STANDARD/examples/cs101-master-balanced/cs101-master-balanced.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs101-master-balanced/cs101-master-balanced.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>cs101_master_balanced</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\examples\cs101-master-balanced\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib60870\lib60870.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/standard/lib60870.NET.STANDARD/examples/cs101-master-balanced/cs101-master-balanced.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs101-master-balanced/cs101-master-balanced.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>cs101_master_balanced</RootNamespace>
   </PropertyGroup>
 

--- a/standard/lib60870.NET.STANDARD/examples/cs101-master-tcp/cs101-master-tcp.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs101-master-tcp/cs101-master-tcp.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>cs101_master_tcp</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\examples\cs101-master-tcp\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib60870\lib60870.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/standard/lib60870.NET.STANDARD/examples/cs101-master-tcp/cs101-master-tcp.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs101-master-tcp/cs101-master-tcp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>cs101_master_tcp</RootNamespace>
   </PropertyGroup>
 

--- a/standard/lib60870.NET.STANDARD/examples/cs101-master-unbalanced/cs101-master-unbalanced.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs101-master-unbalanced/cs101-master-unbalanced.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>cs101_master_unbalanced</RootNamespace>
   </PropertyGroup>
 

--- a/standard/lib60870.NET.STANDARD/examples/cs101-master-unbalanced/cs101-master-unbalanced.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs101-master-unbalanced/cs101-master-unbalanced.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>cs101_master_unbalanced</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\examples\cs101-master-unbalanced\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib60870\lib60870.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/standard/lib60870.NET.STANDARD/examples/cs101-slave-balanced/cs101-slave-balanced.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs101-slave-balanced/cs101-slave-balanced.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>cs101_slave_balanced</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\examples\cs101-slave-balanced\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib60870\lib60870.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/standard/lib60870.NET.STANDARD/examples/cs101-slave-balanced/cs101-slave-balanced.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs101-slave-balanced/cs101-slave-balanced.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>cs101_slave_balanced</RootNamespace>
   </PropertyGroup>
 

--- a/standard/lib60870.NET.STANDARD/examples/cs101-slave-tcp/cs101-slave-tcp.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs101-slave-tcp/cs101-slave-tcp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>cs101_slave_tcp</RootNamespace>
   </PropertyGroup>
 

--- a/standard/lib60870.NET.STANDARD/examples/cs101-slave-tcp/cs101-slave-tcp.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs101-slave-tcp/cs101-slave-tcp.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>cs101_slave_tcp</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\examples\cs101-slave-tcp\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib60870\lib60870.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/standard/lib60870.NET.STANDARD/examples/cs101-slave-unbalanced/cs101-slave-unbalanced.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs101-slave-unbalanced/cs101-slave-unbalanced.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>cs101_slave_unbalanced</RootNamespace>
   </PropertyGroup>
 

--- a/standard/lib60870.NET.STANDARD/examples/cs101-slave-unbalanced/cs101-slave-unbalanced.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs101-slave-unbalanced/cs101-slave-unbalanced.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>cs101_slave_unbalanced</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\examples\cs101-slave-unbalanced\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib60870\lib60870.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/standard/lib60870.NET.STANDARD/examples/cs104-client-file-upload/cs104-client-file-upload.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-client-file-upload/cs104-client-file-upload.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>cs104_client_file_upload</RootNamespace>
   </PropertyGroup>
 

--- a/standard/lib60870.NET.STANDARD/examples/cs104-client-file-upload/cs104-client-file-upload.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-client-file-upload/cs104-client-file-upload.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>cs104_client_file_upload</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\examples\cs104-client-file-upload\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib60870\lib60870.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/standard/lib60870.NET.STANDARD/examples/cs104-client1/cs104-client1.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-client1/cs104-client1.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>cs104_client1</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\examples\cs104-client1\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib60870\lib60870.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/standard/lib60870.NET.STANDARD/examples/cs104-client1/cs104-client1.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-client1/cs104-client1.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>cs104_client1</RootNamespace>
   </PropertyGroup>
 

--- a/standard/lib60870.NET.STANDARD/examples/cs104-client2/cs104-client2.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-client2/cs104-client2.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>cs104_client2</RootNamespace>
   </PropertyGroup>
 

--- a/standard/lib60870.NET.STANDARD/examples/cs104-client2/cs104-client2.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-client2/cs104-client2.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>cs104_client2</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\examples\cs104-client2\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib60870\lib60870.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/standard/lib60870.NET.STANDARD/examples/cs104-client3/cs104-client3.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-client3/cs104-client3.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>cs104_client3</RootNamespace>
   </PropertyGroup>
 

--- a/standard/lib60870.NET.STANDARD/examples/cs104-client3/cs104-client3.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-client3/cs104-client3.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>cs104_client3</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\examples\cs104-client3\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib60870\lib60870.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/standard/lib60870.NET.STANDARD/examples/cs104-multi-client-server/cs104-multi-client-server.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-multi-client-server/cs104-multi-client-server.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>cs104_multi_client_server</RootNamespace>
   </PropertyGroup>
 

--- a/standard/lib60870.NET.STANDARD/examples/cs104-multi-client-server/cs104-multi-client-server.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-multi-client-server/cs104-multi-client-server.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>cs104_multi_client_server</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\examples\cs104-multi-client-server\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib60870\lib60870.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/standard/lib60870.NET.STANDARD/examples/cs104-redundancy-server/cs104-redundancy-server.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-redundancy-server/cs104-redundancy-server.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>cs104_redundancy_server</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\examples\cs104-redundancy-server\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib60870\lib60870.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/standard/lib60870.NET.STANDARD/examples/cs104-redundancy-server/cs104-redundancy-server.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-redundancy-server/cs104-redundancy-server.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>cs104_redundancy_server</RootNamespace>
   </PropertyGroup>
 

--- a/standard/lib60870.NET.STANDARD/examples/cs104-server-file/cs104-server-file.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-server-file/cs104-server-file.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>cs104_server_file</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\examples\cs104-server-file\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib60870\lib60870.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/standard/lib60870.NET.STANDARD/examples/cs104-server-file/cs104-server-file.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-server-file/cs104-server-file.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>cs104_server_file</RootNamespace>
   </PropertyGroup>
 

--- a/standard/lib60870.NET.STANDARD/examples/cs104-server/cs104-server.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-server/cs104-server.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>cs104_server</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\examples\cs104-server\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib60870\lib60870.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/standard/lib60870.NET.STANDARD/examples/cs104-server/cs104-server.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-server/cs104-server.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>cs104_server</RootNamespace>
   </PropertyGroup>
 

--- a/standard/lib60870.NET.STANDARD/examples/cs104-server2/cs104-server2.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-server2/cs104-server2.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>cs104_server2</RootNamespace>
   </PropertyGroup>
 

--- a/standard/lib60870.NET.STANDARD/examples/cs104-server2/cs104-server2.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-server2/cs104-server2.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>cs104_server2</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\examples\cs104-server2\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib60870\lib60870.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/standard/lib60870.NET.STANDARD/examples/cs104-server3/cs104-server3.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-server3/cs104-server3.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>cs104_server3</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\examples\cs104-server3\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib60870\lib60870.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/standard/lib60870.NET.STANDARD/examples/cs104-server3/cs104-server3.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-server3/cs104-server3.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>cs104_server3</RootNamespace>
   </PropertyGroup>
 

--- a/standard/lib60870.NET.STANDARD/examples/cs104-tls-client/cs104-tls-client.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-tls-client/cs104-tls-client.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>cs104_tls_client</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\examples\cs104-tls-client\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib60870\lib60870.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/standard/lib60870.NET.STANDARD/examples/cs104-tls-client/cs104-tls-client.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-tls-client/cs104-tls-client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>cs104_tls_client</RootNamespace>
   </PropertyGroup>
 

--- a/standard/lib60870.NET.STANDARD/examples/cs104-tls-server/cs104-tls-server.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-tls-server/cs104-tls-server.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>cs104_tls_server</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\examples\cs104-tls-server\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib60870\lib60870.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/standard/lib60870.NET.STANDARD/examples/cs104-tls-server/cs104-tls-server.csproj
+++ b/standard/lib60870.NET.STANDARD/examples/cs104-tls-server/cs104-tls-server.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>cs104_tls_server</RootNamespace>
   </PropertyGroup>
 

--- a/standard/lib60870.NET.STANDARD/lib60870.NET.STANDARD.sln
+++ b/standard/lib60870.NET.STANDARD/lib60870.NET.STANDARD.sln
@@ -1,0 +1,139 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.757
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "lib60870", "lib60870\lib60870.csproj", "{CC9BBADD-49E5-4490-A01A-4229025375C0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "lib60870-tests", "tests\lib60870-tests\lib60870-tests.csproj", "{FAC9BBAF-8CED-4522-8185-90EA737FAA9C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "cs104-client1", "examples\cs104-client1\cs104-client1.csproj", "{7E24DB86-F003-4486-A98E-A6730C9D53C9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "cs104-server", "examples\cs104-server\cs104-server.csproj", "{CA2701E5-C18F-4729-97DA-95B747CCE150}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "cs101-master-balanced", "examples\cs101-master-balanced\cs101-master-balanced.csproj", "{2B5D79FF-A079-4460-9796-42C69FC1617B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "cs101-slave-balanced", "examples\cs101-slave-balanced\cs101-slave-balanced.csproj", "{BF47A399-AED7-434D-974D-DF6B5CB52063}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cs101-master-tcp", "examples\cs101-master-tcp\cs101-master-tcp.csproj", "{B62B739F-CCAA-42C6-9818-D30F7059B14A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "cs104-client2", "examples\cs104-client2\cs104-client2.csproj", "{E67EA5F0-081E-4C36-892D-D8244AB3DE3C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cs101-master-unbalanced", "examples\cs101-master-unbalanced\cs101-master-unbalanced.csproj", "{B18DB84A-7221-4BC8-AE2E-2FF5390F3594}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cs101-slave-tcp", "examples\cs101-slave-tcp\cs101-slave-tcp.csproj", "{3EB3AD33-0F7F-4C96-BF19-827C934A5DEF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cs101-slave-unbalanced", "examples\cs101-slave-unbalanced\cs101-slave-unbalanced.csproj", "{49F1C34A-7EF2-412C-B1B7-0A04D3D591C0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cs104-client3", "examples\cs104-client3\cs104-client3.csproj", "{F457A6EB-6AE9-466D-8514-944A3C205735}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cs104-client-file-upload", "examples\cs104-client-file-upload\cs104-client-file-upload.csproj", "{F43AE113-C30E-4C24-897D-E0474F15FE89}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cs104-multi-client-server", "examples\cs104-multi-client-server\cs104-multi-client-server.csproj", "{76FBE3F8-D1BE-401B-9D3C-67F541EA5815}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cs104-redundancy-server", "examples\cs104-redundancy-server\cs104-redundancy-server.csproj", "{505F5015-291D-4C91-ACCB-8C2D7310C9AC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cs104-server2", "examples\cs104-server2\cs104-server2.csproj", "{60BBA6DA-3C12-4E73-9884-474F992D5354}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cs104-server3", "examples\cs104-server3\cs104-server3.csproj", "{705EBB15-8313-4A93-BD9D-B375D03E52F7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cs104-server-file", "examples\cs104-server-file\cs104-server-file.csproj", "{634F6450-ACD0-4D68-8D4E-11F9EE393E1E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cs104-tls-client", "examples\cs104-tls-client\cs104-tls-client.csproj", "{15724A7C-8D89-42F3-95B1-7B4D7B077DCB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cs104-tls-server", "examples\cs104-tls-server\cs104-tls-server.csproj", "{8BD43FEB-08E5-40D9-A603-9825ECD4619D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CC9BBADD-49E5-4490-A01A-4229025375C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC9BBADD-49E5-4490-A01A-4229025375C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC9BBADD-49E5-4490-A01A-4229025375C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC9BBADD-49E5-4490-A01A-4229025375C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FAC9BBAF-8CED-4522-8185-90EA737FAA9C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FAC9BBAF-8CED-4522-8185-90EA737FAA9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FAC9BBAF-8CED-4522-8185-90EA737FAA9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FAC9BBAF-8CED-4522-8185-90EA737FAA9C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E24DB86-F003-4486-A98E-A6730C9D53C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E24DB86-F003-4486-A98E-A6730C9D53C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E24DB86-F003-4486-A98E-A6730C9D53C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E24DB86-F003-4486-A98E-A6730C9D53C9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CA2701E5-C18F-4729-97DA-95B747CCE150}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CA2701E5-C18F-4729-97DA-95B747CCE150}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CA2701E5-C18F-4729-97DA-95B747CCE150}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CA2701E5-C18F-4729-97DA-95B747CCE150}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B5D79FF-A079-4460-9796-42C69FC1617B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B5D79FF-A079-4460-9796-42C69FC1617B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B5D79FF-A079-4460-9796-42C69FC1617B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B5D79FF-A079-4460-9796-42C69FC1617B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF47A399-AED7-434D-974D-DF6B5CB52063}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF47A399-AED7-434D-974D-DF6B5CB52063}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF47A399-AED7-434D-974D-DF6B5CB52063}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF47A399-AED7-434D-974D-DF6B5CB52063}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B62B739F-CCAA-42C6-9818-D30F7059B14A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B62B739F-CCAA-42C6-9818-D30F7059B14A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B62B739F-CCAA-42C6-9818-D30F7059B14A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B62B739F-CCAA-42C6-9818-D30F7059B14A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E67EA5F0-081E-4C36-892D-D8244AB3DE3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E67EA5F0-081E-4C36-892D-D8244AB3DE3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E67EA5F0-081E-4C36-892D-D8244AB3DE3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E67EA5F0-081E-4C36-892D-D8244AB3DE3C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B18DB84A-7221-4BC8-AE2E-2FF5390F3594}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B18DB84A-7221-4BC8-AE2E-2FF5390F3594}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B18DB84A-7221-4BC8-AE2E-2FF5390F3594}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B18DB84A-7221-4BC8-AE2E-2FF5390F3594}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3EB3AD33-0F7F-4C96-BF19-827C934A5DEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3EB3AD33-0F7F-4C96-BF19-827C934A5DEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3EB3AD33-0F7F-4C96-BF19-827C934A5DEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3EB3AD33-0F7F-4C96-BF19-827C934A5DEF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{49F1C34A-7EF2-412C-B1B7-0A04D3D591C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{49F1C34A-7EF2-412C-B1B7-0A04D3D591C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{49F1C34A-7EF2-412C-B1B7-0A04D3D591C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{49F1C34A-7EF2-412C-B1B7-0A04D3D591C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F457A6EB-6AE9-466D-8514-944A3C205735}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F457A6EB-6AE9-466D-8514-944A3C205735}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F457A6EB-6AE9-466D-8514-944A3C205735}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F457A6EB-6AE9-466D-8514-944A3C205735}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F43AE113-C30E-4C24-897D-E0474F15FE89}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F43AE113-C30E-4C24-897D-E0474F15FE89}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F43AE113-C30E-4C24-897D-E0474F15FE89}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F43AE113-C30E-4C24-897D-E0474F15FE89}.Release|Any CPU.Build.0 = Release|Any CPU
+		{76FBE3F8-D1BE-401B-9D3C-67F541EA5815}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{76FBE3F8-D1BE-401B-9D3C-67F541EA5815}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{76FBE3F8-D1BE-401B-9D3C-67F541EA5815}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{76FBE3F8-D1BE-401B-9D3C-67F541EA5815}.Release|Any CPU.Build.0 = Release|Any CPU
+		{505F5015-291D-4C91-ACCB-8C2D7310C9AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{505F5015-291D-4C91-ACCB-8C2D7310C9AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{505F5015-291D-4C91-ACCB-8C2D7310C9AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{505F5015-291D-4C91-ACCB-8C2D7310C9AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60BBA6DA-3C12-4E73-9884-474F992D5354}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{60BBA6DA-3C12-4E73-9884-474F992D5354}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60BBA6DA-3C12-4E73-9884-474F992D5354}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{60BBA6DA-3C12-4E73-9884-474F992D5354}.Release|Any CPU.Build.0 = Release|Any CPU
+		{705EBB15-8313-4A93-BD9D-B375D03E52F7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{705EBB15-8313-4A93-BD9D-B375D03E52F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{705EBB15-8313-4A93-BD9D-B375D03E52F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{705EBB15-8313-4A93-BD9D-B375D03E52F7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{634F6450-ACD0-4D68-8D4E-11F9EE393E1E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{634F6450-ACD0-4D68-8D4E-11F9EE393E1E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{634F6450-ACD0-4D68-8D4E-11F9EE393E1E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{634F6450-ACD0-4D68-8D4E-11F9EE393E1E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{15724A7C-8D89-42F3-95B1-7B4D7B077DCB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{15724A7C-8D89-42F3-95B1-7B4D7B077DCB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{15724A7C-8D89-42F3-95B1-7B4D7B077DCB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{15724A7C-8D89-42F3-95B1-7B4D7B077DCB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8BD43FEB-08E5-40D9-A603-9825ECD4619D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BD43FEB-08E5-40D9-A603-9825ECD4619D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BD43FEB-08E5-40D9-A603-9825ECD4619D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BD43FEB-08E5-40D9-A603-9825ECD4619D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1C2912E6-899F-4145-8003-1F2848786310}
+	EndGlobalSection
+EndGlobal

--- a/standard/lib60870.NET.STANDARD/lib60870/Properties/AssemblyInfo.cs
+++ b/standard/lib60870.NET.STANDARD/lib60870/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("lib60870-tests")]

--- a/standard/lib60870.NET.STANDARD/lib60870/lib60870.csproj
+++ b/standard/lib60870.NET.STANDARD/lib60870/lib60870.csproj
@@ -1,0 +1,88 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>2.3.0</Version>
+    <Company>MZ Automation GmbH</Company>
+    <Product>lib60870.NET</Product>
+    <Description>IEC 60870-5-101/104 protocol library</Description>
+    <AssemblyVersion>2.3.0.0</AssemblyVersion>
+    <FileVersion>2.3.0.0</FileVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\lib60870\ASDUParsingException.cs" Link="ASDUParsingException.cs" />
+    <Compile Include="..\..\..\lib60870\BufferFrame.cs" Link="BufferFrame.cs" />
+    <Compile Include="..\..\..\lib60870\ConnectionException.cs" Link="ConnectionException.cs" />
+    <Compile Include="..\..\..\lib60870\CP16Time2a.cs" Link="CP16Time2a.cs" />
+    <Compile Include="..\..\..\lib60870\CP24Time2a.cs" Link="CP24Time2a.cs" />
+    <Compile Include="..\..\..\lib60870\CP32Time2a.cs" Link="CP32Time2a.cs" />
+    <Compile Include="..\..\..\lib60870\CP56Time2a.cs" Link="CP56Time2a.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\ApplicationLayerParameters.cs" Link="CS101\ApplicationLayerParameters.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\ASDU.cs" Link="CS101\ASDU.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\BinaryCounterReading.cs" Link="CS101\BinaryCounterReading.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\Bitstring32.cs" Link="CS101\Bitstring32.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\CauseOfTransmission.cs" Link="CS101\CauseOfTransmission.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\CS101Master.cs" Link="CS101\CS101Master.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\CS101Slave.cs" Link="CS101\CS101Slave.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\DoublePointInformation.cs" Link="CS101\DoublePointInformation.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\EndOfInitialization.cs" Link="CS101\EndOfInitialization.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\EventOfProtectionEquipment.cs" Link="CS101\EventOfProtectionEquipment.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\FileObjects.cs" Link="CS101\FileObjects.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\FileServices.cs" Link="CS101\FileServices.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\InformationObject.cs" Link="CS101\InformationObject.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\IntegratedTotals.cs" Link="CS101\IntegratedTotals.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\Master.cs" Link="CS101\Master.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\MeasuredValueNormalized.cs" Link="CS101\MeasuredValueNormalized.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\MeasuredValueScaled.cs" Link="CS101\MeasuredValueScaled.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\MeasuredValueShort.cs" Link="CS101\MeasuredValueShort.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\OutputCircuitInfo.cs" Link="CS101\OutputCircuitInfo.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\PackedOutputCircuitInfo.cs" Link="CS101\PackedOutputCircuitInfo.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\PackedStartEventsOfProtectionEquipment.cs" Link="CS101\PackedStartEventsOfProtectionEquipment.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\ParameterMeasuredValues.cs" Link="CS101\ParameterMeasuredValues.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\QualityDescriptor.cs" Link="CS101\QualityDescriptor.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\QualityDescriptorP.cs" Link="CS101\QualityDescriptorP.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\ScaledValue.cs" Link="CS101\ScaledValue.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\SetpointCommandQualifier.cs" Link="CS101\SetpointCommandQualifier.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\SetpointCommands.cs" Link="CS101\SetpointCommands.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\SingleCommand.cs" Link="CS101\SingleCommand.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\SingleCommandQualifier.cs" Link="CS101\SingleCommandQualifier.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\SingleEvent.cs" Link="CS101\SingleEvent.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\SinglePointInformation.cs" Link="CS101\SinglePointInformation.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\Slave.cs" Link="CS101\Slave.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\StartEvent.cs" Link="CS101\StartEvent.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\StatusAndStatusChangeDetection.cs" Link="CS101\StatusAndStatusChangeDetection.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\StepPositionInformation.cs" Link="CS101\StepPositionInformation.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\SystemInformationCommands.cs" Link="CS101\SystemInformationCommands.cs" />
+    <Compile Include="..\..\..\lib60870\CS101\TypeID.cs" Link="CS101\TypeID.cs" />
+    <Compile Include="..\..\..\lib60870\CS104\APCIParameters.cs" Link="CS104\APCIParameters.cs" />
+    <Compile Include="..\..\..\lib60870\CS104\ClientConnection.cs" Link="CS104\ClientConnection.cs" />
+    <Compile Include="..\..\..\lib60870\CS104\Connection.cs" Link="CS104\Connection.cs" />
+    <Compile Include="..\..\..\lib60870\CS104\Server.cs" Link="CS104\Server.cs" />
+    <Compile Include="..\..\..\lib60870\CS104\TlsSecurityInformation.cs" Link="CS104\TlsSecurityInformation.cs" />
+    <Compile Include="..\..\..\lib60870\Frame.cs" Link="Frame.cs" />
+    <Compile Include="..\..\..\lib60870\LibraryCommon.cs" Link="LibraryCommon.cs" />
+    <Compile Include="..\..\..\lib60870\LinkLayer\LinkLayer.cs" Link="LinkLayer\LinkLayer.cs" />
+    <Compile Include="..\..\..\lib60870\LinkLayer\PrimaryLinkLayer.cs" Link="LinkLayer\PrimaryLinkLayer.cs" />
+    <Compile Include="..\..\..\lib60870\LinkLayer\PrimaryLinkLayerBalanced.cs" Link="LinkLayer\PrimaryLinkLayerBalanced.cs" />
+    <Compile Include="..\..\..\lib60870\LinkLayer\PrimaryLinkLayerUnbalanced.cs" Link="LinkLayer\PrimaryLinkLayerUnbalanced.cs" />
+    <Compile Include="..\..\..\lib60870\LinkLayer\SecondaryLinkLayer.cs" Link="LinkLayer\SecondaryLinkLayer.cs" />
+    <Compile Include="..\..\..\lib60870\LinkLayer\SecondaryLinkLayerBalanced.cs" Link="LinkLayer\SecondaryLinkLayerBalanced.cs" />
+    <Compile Include="..\..\..\lib60870\LinkLayer\SecondaryLinkLayerUnbalanced.cs" Link="LinkLayer\SecondaryLinkLayerUnbalanced.cs" />
+    <Compile Include="..\..\..\lib60870\LinkLayer\SerialTransceiverFT12.cs" Link="LinkLayer\SerialTransceiverFT12.cs" />
+    <Compile Include="..\..\..\lib60870\LinkLayer\TcpClientVirtualSerialPort.cs" Link="LinkLayer\TcpClientVirtualSerialPort.cs" />
+    <Compile Include="..\..\..\lib60870\LinkLayer\TcpServerVirtualSerialPort.cs" Link="LinkLayer\TcpServerVirtualSerialPort.cs" />
+    <Compile Include="..\..\..\lib60870\SystemUtils.cs" Link="SystemUtils.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="CS101\" />
+    <Folder Include="CS104\" />
+    <Folder Include="LinkLayer\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.IO.Ports" Version="4.5.0" />
+  </ItemGroup>
+
+</Project>

--- a/standard/lib60870.NET.STANDARD/tests/lib60870-tests/lib60870-tests.csproj
+++ b/standard/lib60870.NET.STANDARD/tests/lib60870-tests/lib60870-tests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\..\tests\Test.cs" Link="Test.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.14.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib60870\lib60870.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/standard/lib60870.NET.STANDARD/tests/lib60870-tests/lib60870-tests.csproj
+++ b/standard/lib60870.NET.STANDARD/tests/lib60870-tests/lib60870-tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
New solution and projects to build the library for .NET Standard 2.

It supports both protocols: IEC-101 and IEC-104. The support of IEC-101 depends on the [System.IO.Ports](https://www.nuget.org/packages/System.IO.Ports/4.5.0) package and currently only works on Windows. The next release of this package (4.6.0) will add support for Linux/macOS.