### PR TITLE
Receiving an I or S frame while in STOPDT should shut down the connection

### DIFF
--- a/lib60870/CS104/ClientConnection.cs
+++ b/lib60870/CS104/ClientConnection.cs
@@ -972,7 +972,8 @@ namespace lib60870.CS104
                 else
                 {
                     // connection not activated --> skip message
-                    DebugLog("Connection not activated. Skip I message");
+                    DebugLog("Connection not activated. Skip I message and shut down connection");
+                    return false;
                 }
             }
 
@@ -1028,6 +1029,11 @@ namespace lib60870.CS104
 			// S-message
 			else if (buffer[2] == 0x01)
             {
+                if(this.isActive == false)
+                {
+                    DebugLog("Connection not activated. Skip S message and shut down connection");
+                    return false;
+                }
 
                 int seqNo = (buffer[4] + buffer[5] * 0x100) / 2;
 


### PR DESCRIPTION
According to spec, when you receive an I or S frame in STOPDT mode, the connection should be shut down as this is an error.

We ran into this issue today during a conformance test and found out that it's not something that can be handled outside the library, so I made these small changes.