### PR TITLE
Bugfix: TLS version to be picked up from config - it is currently hardwired

### DIFF
--- a/lib60870/CS104/ClientConnection.cs
+++ b/lib60870/CS104/ClientConnection.cs
@@ -1242,7 +1242,7 @@ namespace lib60870.CS104
 
                         try
                         {
-                            sslStream.AuthenticateAsServer(tlsSecInfo.OwnCertificate, true, System.Security.Authentication.SslProtocols.Tls, false);
+                            sslStream.AuthenticateAsServer(tlsSecInfo.OwnCertificate, true, tlsSecInfo.TlsVersion, false);
 						
                             if (sslStream.IsAuthenticated == true)
                             {


### PR DESCRIPTION
BUG: TLS version is hardwired to TLS 1.0 
It should be picked up from the tlsSecInfo object.
This bug prevents the use of TLS as Tls 1.0 is not supported anymore (in most cases)
The default `None` setting will then also makes sense, and lets the operating system pick the best available protocol, see:

https://learn.microsoft.com/en-us/dotnet/api/System.Security.Authentication.SslProtocols?view=net-7.0
